### PR TITLE
Expand consulting landing and add Oct 2025 DNS log

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This repository will power the service-facing side of 28eme at https://28eme.ca. It complements the personal site at https://austinbjohnson.com by focusing on automation consulting, composite AI experiments, and case studies.
 
 ## Initial To-Do
-- [ ] Finalize site information architecture (Home, Services, Process, Experiments, Contact).
-- [ ] Draft hero copy and CTA aligned with the consulting offer.
+- [x] Finalize site information architecture (Home, Services, Process, Experiments, Contact).
+- [x] Draft hero copy and CTA aligned with the consulting offer.
 - [ ] Add visual identity elements that relate to the personal site while feeling distinct.
 - [ ] Connect GitHub Pages (`main` branch) and point the `28eme.ca` domain.
 - [ ] Link back to the personal site in navigation and footer.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,5 +2,6 @@
 
 | Date       | Change | Notes |
 |------------|--------|-------|
+| 2025-10-07 | Expanded consulting landing and logged DNS check. | Added service/process sections, updated CTAs, and recorded domain status in `docs/log-oct-2025/2025-10-07.md`. |
 | 2025-02-14 | Scaffolded repo structure locally. | Added docs hierarchy, placeholder index, and planning outlines. |
 | 2025-10-06 | Pointed `28eme.ca` at GitHub Pages and redirected `28eme.com`. | Added Squarespace DNS + forwarding notes; live domain now serves consulting placeholder. |

--- a/docs/log-oct-2025/2025-10-07.md
+++ b/docs/log-oct-2025/2025-10-07.md
@@ -1,0 +1,13 @@
+# 2025-10-07 — Content Pass + DNS Check
+
+**Focus:** convert placeholder landing into consulting-ready messaging and confirm live domain status.
+
+## Domain Observations
+- `https://28eme.ca` returns `200` over HTTPS from GitHub Pages (`curl -I` at 2025-10-07 04:21 UTC).
+- `https://28eme.com` currently 301s to `http://28eme.ca` via Squarespace forwarding; mirror across `https://`.
+- `https://www.28eme.com` is not resolving yet (likely Squarespace `www` forwarding delay); recheck during the next pass.
+
+## Content Updates
+- Replaced the “What’s coming” placeholder with services, process, experience, and proof sections.
+- Tuned hero copy and CTAs to align with the automation-first consulting offer.
+- Captured session context in `handoff.md` and ensured next actions stay visible.

--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,13 @@
+# Handoff Reference
+
+This repo follows the shared workflow documented at the websites root.
+
+- Master session notes: `../handoff/SESSION_NOTES.md`
+- Co-dev reminders: `../REMINDER.md`
+
+## Site-Specific Notes
+
+- [x] After next content pass, log the verified `28eme.ca` / `.com` DNS status in `docs/log-oct-2025`.
+- [x] Flesh out the service/process narrative and iterate on the production layout.
+- [x] Adapt the "About Austin" story into a consulting-focused portfolio with sections for experience snapshots, offer, and proof points.
+- [ ] Re-check `https://www.28eme.com` once Squarespace forwarding finishes and update the DNS log with the result.

--- a/index.html
+++ b/index.html
@@ -112,6 +112,102 @@
       backdrop-filter: blur(9px);
       box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
     }
+    .section-lead {
+      max-width: 45rem;
+      color: var(--muted);
+      font-size: 1.02rem;
+      margin-bottom: 1.6rem;
+    }
+    .grid {
+      display: grid;
+      gap: 1.4rem;
+    }
+    .grid.three {
+      grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    }
+    .grid.two {
+      grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    }
+    .service-card h3 {
+      margin: 0 0 0.6rem;
+      font-size: 1.28rem;
+    }
+    .service-card p {
+      margin: 0 0 0.95rem;
+      color: var(--muted);
+    }
+    .focus-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.45rem;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+    .focus-list li {
+      position: relative;
+      padding-left: 1.35rem;
+    }
+    .focus-list li::before {
+      content: "•";
+      position: absolute;
+      left: 0.3rem;
+      top: 0;
+      color: var(--accent);
+      font-size: 1.1rem;
+      line-height: 1;
+    }
+    .stage-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      counter-reset: stage;
+      display: grid;
+      gap: 1rem;
+    }
+    .stage-list li {
+      counter-increment: stage;
+      position: relative;
+      padding: 1.9rem 1.8rem 1.7rem 4.4rem;
+      border-radius: 1.4rem;
+      border: 1px solid var(--border);
+      background: rgba(12, 18, 26, 0.75);
+      backdrop-filter: blur(9px);
+    }
+    .stage-list li::before {
+      content: "0" counter(stage);
+      position: absolute;
+      left: 1.7rem;
+      top: 1.85rem;
+      font-weight: 700;
+      font-size: 1rem;
+      letter-spacing: 0.08em;
+      color: var(--accent);
+    }
+    .stage-list h3 {
+      margin: 0 0 0.5rem;
+      font-size: 1.28rem;
+    }
+    .stage-list p {
+      margin: 0 0 0.8rem;
+      color: var(--muted);
+    }
+    .split {
+      display: grid;
+      gap: 1.6rem;
+      grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+      align-items: start;
+    }
+    .note {
+      margin-top: 1.2rem;
+      padding: 1rem 1.2rem;
+      border-radius: 0.9rem;
+      border: 1px dashed var(--border);
+      color: var(--muted);
+      background: rgba(5, 7, 11, 0.6);
+      font-size: 0.9rem;
+    }
     footer {
       padding: 1.5rem;
       border-top: 1px solid var(--border);
@@ -123,27 +219,158 @@
     a {
       color: var(--accent);
     }
+    @media (max-width: 640px) {
+      .cta-group {
+        width: 100%;
+      }
+      .cta {
+        flex: 1;
+        justify-content: center;
+      }
+      .stage-list li {
+        padding-left: 3.6rem;
+      }
+    }
   </style>
 </head>
 <body>
   <header>
     <div class="container">
       <span class="eyebrow">Automation consulting</span>
-      <h1>28eme helps teams operationalize composite AI with automation-first workflows.</h1>
-      <p class="lead">Austin Johnson’s consulting studio for shipping agents, orchestrating APIs, and documenting the systems that keep teams moving. Companion to the personal hub at <a href="https://austinbjohnson.com" target="_blank" rel="noopener">austinbjohnson.com</a>.</p>
+      <h1>Automation-first consulting for teams operationalizing composite AI.</h1>
+      <p class="lead">28eme is Austin Johnson’s studio for designing agents, orchestrating APIs, and documenting the operating playbooks that keep teams moving. Companion to the personal hub at <a href="https://austinbjohnson.com" target="_blank" rel="noopener">austinbjohnson.com</a>.</p>
       <div class="cta-group">
-        <a class="cta" href="mailto:hello@28eme.com?subject=Work%20with%2028eme">Start a project</a>
-        <a class="cta secondary" href="https://austinbjohnson.com" target="_blank" rel="noopener">Personal site</a>
+        <a class="cta" href="mailto:hello@28eme.com?subject=Start%20an%20automation%20engagement">Start a project</a>
+        <a class="cta secondary" href="https://github.com/austinbjohnson" target="_blank" rel="noopener">Public experiments</a>
       </div>
     </div>
   </header>
 
   <main>
     <div class="container">
-      <section>
-        <h2>What’s coming</h2>
+      <section id="services">
+        <h2>Engagement focus</h2>
+        <p class="section-lead">28eme partners with operations leaders, founders, and creative teams who need automation-first systems that keep pace with composite AI. Each engagement balances experimentation with documentation so the work keeps delivering after handoff.</p>
+        <div class="grid three">
+          <article class="card service-card">
+            <h3>Composite AI in production</h3>
+            <p>Design multi-agent systems that combine LLMs, APIs, and human review so automations stay resilient.</p>
+            <ul class="focus-list">
+              <li>Agent choreography mapped to the jobs-to-be-done you outline.</li>
+              <li>Fallbacks, observability, and audit trails built into every flow.</li>
+            </ul>
+          </article>
+          <article class="card service-card">
+            <h3>Automation playbooks</h3>
+            <p>Codify the workflows that let your team ship without waiting on additional engineering cycles.</p>
+            <ul class="focus-list">
+              <li>Reusable prototypes across Zapier, Make, Airtable, and bespoke services.</li>
+              <li>Configuration notes, triggers, and maintenance cadence documented in plain language.</li>
+            </ul>
+          </article>
+          <article class="card service-card">
+            <h3>Documentation & handoff</h3>
+            <p>Every build ships with the artifacts you need to keep iterating—no black boxes left behind.</p>
+            <ul class="focus-list">
+              <li>Architecture maps, data flow diagrams, and dependency checklists.</li>
+              <li>Loom walkthroughs, runbooks, and a backlog of next bets.</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section id="process">
+        <h2>How engagements run</h2>
+        <p class="section-lead">A lightweight, documented path keeps everyone aligned from the first mapping session to the final handoff.</p>
+        <ol class="stage-list">
+          <li>
+            <h3>Discover</h3>
+            <p>Clarity sessions to map the workflow, surface constraints, and lock the signals that prove success.</p>
+            <ul class="focus-list">
+              <li>Async intake followed by a working session around jobs-to-be-done.</li>
+              <li>Inventory of systems, data access, and approval gates.</li>
+            </ul>
+          </li>
+          <li>
+            <h3>Design</h3>
+            <p>Prototype agents and automations, stress-test data flows, and plan the governance story.</p>
+            <ul class="focus-list">
+              <li>Clickable or running prototypes for fast feedback.</li>
+              <li>Architecture notes covering models, triggers, and human-in-the-loop safeties.</li>
+            </ul>
+          </li>
+          <li>
+            <h3>Deliver</h3>
+            <p>Implement, document, train, and iterate with built-in feedback loops before the final handoff.</p>
+            <ul class="focus-list">
+              <li>Enablement sessions and Loom walkthroughs for your team.</li>
+              <li>Runbooks, metrics snapshot, and backlog for the next release.</li>
+            </ul>
+          </li>
+        </ol>
+        <div class="note">Weekly async status updates, Loom walkthroughs, and a shared workspace keep stakeholders in the loop without adding meeting overhead.</div>
+      </section>
+
+      <section id="experience">
+        <h2>Experience & approach</h2>
         <div class="card">
-          <p>This placeholder will grow into the full consulting site. Upcoming sections: services, process, automation experiments, and selected case studies. Content drafts live in <code>docs/</code>.</p>
+          <div class="split">
+            <div>
+              <p>Austin Johnson is an AI-native product manager and founder of 28eme. Years of shipping automation-first experiences at Zapier and inside his own studio shaped a problem-first, documentation-heavy approach. The goal is always the same: bend APIs, events, and agents so people feel less friction.</p>
+              <p>Every engagement maps the job-to-be-done, composes the right agents around it, and ships iteratively in public where possible. The craft shows up in the details—shared repos, transparent changelogs, and artifacts your team can maintain without outside help.</p>
+            </div>
+            <div>
+              <h3 style="margin-top:0;">Ideal collaborators</h3>
+              <ul class="focus-list">
+                <li>Operations teams building automation capacity without adding headcount.</li>
+                <li>Founders validating AI-native product bets before a full engineering build.</li>
+                <li>Studios exploring bespoke workflows that bridge no-code and engineering.</li>
+              </ul>
+              <h3>What you take with you</h3>
+              <ul class="focus-list">
+                <li>Documented architecture, API maps, and risk considerations.</li>
+                <li>Reusable automation playbooks with configuration notes.</li>
+                <li>Training assets and a next-step backlog to keep momentum.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="proof">
+        <h2>Proof & experiments</h2>
+        <div class="card">
+          <p class="section-lead" style="margin-bottom:1.4rem;">Case studies are anonymized until approvals land, but the patterns repeat: operational relief, faster shipping, and clarity around how automation supports the work.</p>
+          <div class="grid two">
+            <div>
+              <h3 style="margin-top:0;">Case studies in flight</h3>
+              <ul class="focus-list">
+                <li>Support triage agents reducing manual routing across tooling silos.</li>
+                <li>Product operations automation syncing release notes across stacks.</li>
+                <li>Personal knowledge assistants documenting craft projects and routines.</li>
+              </ul>
+            </div>
+            <div>
+              <h3 style="margin-top:0;">Public experiments</h3>
+              <ul class="focus-list">
+                <li>Composite agent prototypes across Zapier, Airtable, Notion, and custom APIs.</li>
+                <li>Automation dashboards for cyclists, readers, and makers—proving bespoke workflows scale.</li>
+                <li>Knowledge capture tooling with human-in-the-loop reviews for accountability.</li>
+              </ul>
+            </div>
+          </div>
+          <div class="note">Request a walkthrough to see anonymized artifacts, Loom demos, and the metrics snapshot format used at handoff.</div>
+        </div>
+      </section>
+
+      <section id="cta">
+        <div class="card">
+          <h2 style="margin-top:0;">Ready for the next build?</h2>
+          <p style="color:var(--muted);">Share your scenario and 28eme will outline a discovery path or scoped experiment within 48 hours.</p>
+          <div class="cta-group" style="margin-top:1.6rem;">
+            <a class="cta" href="mailto:hello@28eme.com?subject=Start%20an%20automation%20engagement">Start a project</a>
+            <a class="cta secondary" href="https://github.com/austinbjohnson/28eme-site/tree/main/docs" target="_blank" rel="noopener">Browse the playbooks</a>
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- replace the placeholder body with services, process, experience, proof, and CTA sections tailored to the consulting offer
- capture the Oct 2025 DNS verification in a new `docs/log-oct-2025` entry and update the handoff + changelog with the latest context
- mark roadmap progress in the README so the initial to-do list mirrors the new copy work

## Testing
- [x] `curl -I https://28eme.ca`
- [x] `curl -I https://28eme.com`
- [ ] `curl -I https://www.28eme.com` *(still pending resolution; logged follow-up)*