### PR TITLE
Remove playbooks CTA from closing section

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,7 +314,6 @@
           <p style="color:var(--muted);">Share your scenario and get a scoped experiment or discovery path within 48 hours.</p>
           <div class="cta-group" style="margin-top:1.6rem;">
             <a class="cta" href="mailto:hello@28eme.com?subject=Start%20an%20automation%20engagement">Start a project</a>
-            <a class="cta secondary" href="https://github.com/austinbjohnson/28eme-site/tree/main/docs" target="_blank" rel="noopener">Browse the playbooks</a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- drop the secondary "Browse the playbooks" call-to-action from the closing card
- leave the primary email CTA centered so the footer focus stays on direct outreach

## Testing
- none (static HTML)