### PR TITLE
Update card labels and add studio tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,11 @@
       margin: 0;
       max-width: 38rem;
     }
+    .studio-note {
+      margin: 1.5rem 0 0;
+      font-size: 0.88rem;
+      color: var(--neutral);
+    }
     main {
       flex: 1;
       padding-bottom: 4rem;
@@ -212,6 +217,7 @@
       <span class="eyebrow">28eme Studio</span>
       <h1>PM building Enterprise AI Orchestration at Zapier.</h1>
       <p class="lead">Focused on composite AI and governance—helping teams ship AI workflows that stay accountable at scale.</p>
+      <p class="studio-note">28eme is the Modern PM and Automation Studio founded by Austin Johnson.</p>
     </div>
   </header>
 
@@ -224,7 +230,7 @@
           <p>Enterprise AI Orchestration, composite AI, and governance at scale.</p>
         </article>
         <article class="card accent-gold">
-          <span class="label">Internal Initiative</span>
+          <span class="label">Zapier</span>
           <h2>AI Innovation Lead</h2>
           <p>Driving a new way of working for PMs with AI-native tooling.</p>
         </article>


### PR DESCRIPTION
## Summary
- Both role cards now show "ZAPIER" label
- Added studio tagline: "28eme is the Modern PM and Automation Studio founded by Austin Johnson."

## Test plan
- [ ] Verify both cards show Zapier label
- [ ] Verify studio tagline appears below lead text

🤖 Generated with [Claude Code](https://claude.com/claude-code)